### PR TITLE
Change imports to relative for Python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 sudo: required
 python:
   - "2.7"
+  - "3.6"
 before_install:
   - pip install pytest
 install:

--- a/fair/__init__.py
+++ b/fair/__init__.py
@@ -6,7 +6,7 @@
 
 
 # # # ------------ IMPORT REQUIRED MODULES ------------ # # #
-import forward
+from . import forward
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/fair/forward.py
+++ b/fair/forward.py
@@ -1,10 +1,10 @@
 import inspect
 import numpy as np
 from scipy.optimize import root
-from constants import molwt, lifetime, radeff
-from constants.general import M_ATMOS
-from forcing import ozone_tr, ozone_st, h2o_st, contrails, aerosols, bc_snow,\
-                    landuse
+from .constants import molwt, lifetime, radeff
+from .constants.general import M_ATMOS
+from .forcing import ozone_tr, ozone_st, h2o_st, contrails, aerosols, bc_snow,\
+                     landuse
 
 def iirf_interp_funct(alp_b,a,tau,targ_iirf):
 	# ref eq. (7) of Millar et al ACP (2017)
@@ -89,9 +89,9 @@ def fair_scm(emissions=False,
       lifetimes = lifetime.aslist
     # Select the desired GHG forcing relationship
     if ghg_forcing.lower()=="etminan":
-      from forcing.ghg import etminan as ghg
+      from .forcing.ghg import etminan as ghg
     elif ghg_forcing.lower()=="myhre":
-      from forcing.ghg import myhre as ghg
+      from .forcing.ghg import myhre as ghg
     else:
       raise ValueError("ghg_forcing should be 'etminan' (default) or 'myhre'")
       

--- a/index.ipynb
+++ b/index.ipynb
@@ -69,7 +69,7 @@
     "from matplotlib import pyplot as plt\n",
     "plt.style.use('seaborn-darkgrid')\n",
     "plt.rcParams['figure.figsize'] = 16, 9\n",
-    "print plt.style"
+    "print(plt.style)"
    ]
   },
   {


### PR DESCRIPTION
Great work, nice to see a fully Python-based SCM.
I've made changes to the imports to be relative which I think should work for both 2.7 and Python3:

Python3
```
(venv) robert@pikbook ~/s/FAIR (py3-compatibility)> pytest tests/ --verbose
================ test session starts 
platform linux -- Python 3.6.1, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/robert/sources/FAIR/venv/bin/python3.6
cachedir: .cache
rootdir: /home/robert/sources/FAIR, inifile:
collected 9 items                                                                                                                                                                                                 

tests/test_fair.py::test_import PASSED                                                                                                                                                                      [ 11%]
tests/test_fair.py::test_no_arguments PASSED                                                                                                                                                                [ 22%]
tests/test_fair.py::test_zero_emissions PASSED                                                                                                                                                              [ 33%]
tests/test_fair.py::test_ten_GtC_pulse PASSED                                                                                                                                                               [ 44%]
tests/test_fair.py::test_multigas_fullemissions_error PASSED                                                                                                                                                [ 55%]
tests/test_fair.py::test_rcp3pd PASSED                                                                                                                                                                      [ 66%]
tests/test_fair.py::test_rcp45 PASSED                                                                                                                                                                       [ 77%]
tests/test_fair.py::test_rcp6 PASSED                                                                                                                                                                        [ 88%]
tests/test_fair.py::test_rcp85 PASSED                                                                                                                                                                       [100%]

============= 9 passed
```

Python 2

```
================ test session starts 
platform linux2 -- Python 2.7.13, pytest-3.3.2, py-1.5.2, pluggy-0.6.0 -- /home/robert/sources/FAIR/venv2/bin/python2
cachedir: .cache
rootdir: /home/robert/sources/FAIR, inifile:
collected 9 items                                                                                                                                                                                                 

tests/test_fair.py::test_import PASSED                                                                                                                                                                      [ 11%]
tests/test_fair.py::test_no_arguments PASSED                                                                                                                                                                [ 22%]
tests/test_fair.py::test_zero_emissions PASSED                                                                                                                                                              [ 33%]
tests/test_fair.py::test_ten_GtC_pulse PASSED                                                                                                                                                               [ 44%]
tests/test_fair.py::test_multigas_fullemissions_error PASSED                                                                                                                                                [ 55%]
tests/test_fair.py::test_rcp3pd PASSED                                                                                                                                                                      [ 66%]
tests/test_fair.py::test_rcp45 PASSED                                                                                                                                                                       [ 77%]
tests/test_fair.py::test_rcp6 PASSED                                                                                                                                                                        [ 88%]
tests/test_fair.py::test_rcp85 PASSED                                                                                                                                                                       [100%]
============= 9 passed
```

