### PR TITLE
Ensure true division

### DIFF
--- a/fair/forcing/aerosols.py
+++ b/fair/forcing/aerosols.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 from ..constants import molwt
 

--- a/fair/forcing/bc_snow.py
+++ b/fair/forcing/bc_snow.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 def linear(emissions, E_ref=8.09, F_ref=0.04):
     E_BC = emissions[:,9]
     return E_BC * F_ref/E_ref

--- a/fair/forcing/contrails.py
+++ b/fair/forcing/contrails.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 from ..constants import molwt
 

--- a/fair/forcing/ghg.py
+++ b/fair/forcing/ghg.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 
 def etminan(C, Cpi, F2x=3.74):

--- a/fair/forcing/h2o_st.py
+++ b/fair/forcing/h2o_st.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 
 def linear(F_CH4, ratio=0.15):

--- a/fair/forcing/ozone_st.py
+++ b/fair/forcing/ozone_st.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import numpy as np
 from ..constants import cl_atoms, br_atoms, fracrel
 

--- a/fair/forward.py
+++ b/fair/forward.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import inspect
 import numpy as np
 from scipy.optimize import root

--- a/tests/test_fair.py
+++ b/tests/test_fair.py
@@ -31,9 +31,9 @@ def test_ten_GtC_pulse():
     other_rf = np.zeros(emissions.size)
     for x in range(0,emissions.size):
         other_rf[x] = 0.5*np.sin(2*np.pi*(x)/14.0)
-    
+
     C,F,T = fair.forward.fair_scm(emissions=emissions, other_rf=other_rf)
-    
+
     datadir = os.path.join(os.path.dirname(__file__), 'ten_GtC_pulse/')
     C_expected = np.load(datadir + 'C.npy')
     F_expected = np.load(datadir + 'F.npy')
@@ -104,3 +104,21 @@ def test_rcp85():
     assert np.allclose(C, C_expected)
     assert np.allclose(F, F_expected)
     assert np.allclose(T, T_expected)
+
+
+def test_division():
+    # Ensure parameters given as integers are treated as floats when dividing
+    # (Python2 compatibility).
+    _, _, T = fair.forward.fair_scm(
+        emissions=fair.RCPs.rcp6.Emissions.emissions,
+        useMultigas=True,
+        d=np.array([239.0, 4.0]),
+        tcr_dbl=70.0
+    )
+    _, _, T_int_params = fair.forward.fair_scm(
+        emissions=fair.RCPs.rcp6.Emissions.emissions,
+        useMultigas=True,
+        d=np.array([239, 4]),
+        tcr_dbl=70
+    )
+    assert (T == T_int_params).all()


### PR DESCRIPTION
This enables giving parameters as integers in Python 2.

As brought up in #11 and #12 

Not sure if more tests are needed.