### PR TITLE
Add CSV files when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(name='fair',
       author_email='c.j.smith1@leeds.ac.uk/richard.millar@physics.ox.ac.uk',
       license='Apache 2.0',
       packages=find_packages(exclude=['tests*']),
+      package_data={'': ['*.csv']},
       install_requires=[
           'numpy',
           'scipy',


### PR DESCRIPTION
This adds the CSV files included with FAIR to `setup.py`, enabling `pip install` directly from GitHub (and I assume also when sending to PyPI).