### PR TITLE
Install .pickle file as well

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='fair',
       license='Apache 2.0',
       packages=find_packages(exclude=['tests*']),
       package_data={'': ['*.csv']},
+      include_package_data=True,
       install_requires=[
           'numpy>=1.11.3',
           'scipy>=0.19.0',


### PR DESCRIPTION
With the "pickle" file added I'm getting a file not found error when installing directly from GitHub

    pip install https://github.com/OMS-NetZero/FAIR/archive/v1.2_dev.zip


```
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-5-08823b14a483> in <module>()
----> 1 C26, F26, T26 = fair.forward.fair_scm(emissions=rcp3pd.Emissions.emissions)

~/Work/test/venv/lib/python3.6/site-packages/fair/forward.py in fair_scm(emissions, other_rf, q, tcrecs, d, a, tau, r0, rc, rt, F2x, iirf_max, tcr_dbl, C_pi, restart_in, restart_out, F_volcanic, F_solar, aviNOx_frac, fossilCH4_frac, natural, efficacy, scale, oxCH4_frac, ghg_forcing, stwv_from_ch4, b_aero, b_tro3, useMultigas, useStevenson, lifetimes, aerosol_forcing, scaleAerosolAR5, fixPre1850RCP, useTropO3TFeedback)
    229       if 'ghan' in aerosol_forcing.lower():
    230         F[:,8] = F[:,8] + aerosols.ghan_indirect_emulator(emissions,
--> 231           scale_AR5=scaleAerosolAR5)
    232     else:
    233       raise ValueError("aerosol_forcing should be one of 'stevens', "+

~/Work/test/venv/lib/python3.6/site-packages/fair/forcing/aerosols.py in ghan_indirect_emulator(emissions, fix_pre1850_RCP, scale_AR5)
    121     # http://atucla.blogspot.co.uk/2016/01/save-and-load-rbf-object-fromto-file.html
    122     RBFfile = open(os.path.join(os.path.dirname(__file__),
--> 123         'ghan_emulator.pickle'),'rb')
    124     if sys.version_info > (3,0):
    125         RBFunpickler = pickle.Unpickler(RBFfile, encoding='latin1')

FileNotFoundError: [Errno 2] No such file or directory: '/Users/robert/Work/test/venv/lib/python3.6/site-packages/fair/forcing/ghan_emulator.pickle'
```

It seems adding `include_package_data=True` in setup.py fixes that.

http://setuptools.readthedocs.io/en/latest/setuptools.html#including-data-files

See also here: https://stackoverflow.com/questions/7522250/how-to-include-package-data-with-setuptools-distribute

> Seriously, I feel like this ticket is a group therapy session for folks using setuptools and discovering just what a horrid place they have found themselves in life.

[(StackOverflow)](https://stackoverflow.com/questions/7522250/how-to-include-package-data-with-setuptools-distribute#comment84047044_14159430)

It seems to be complicated. :-)