### PR TITLE
Include data files when installing from GitHub

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include versioneer.py
 include fair/_version.py
+graft fair/RCPs/data
 prune tests*
 prune docs*

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(name='fair',
       license='Apache 2.0',
       packages=find_packages(exclude=['tests*','docs*']),
       package_data={'': ['*.csv']},
+      include_package_data=True,
       install_requires=[
           'numpy>=1.11.3',
           'scipy>=0.19.0',


### PR DESCRIPTION
Hi, I wanted to try out the #39 by installing from GitHub and got an error with missing data files.
The following commits would allow me to do an install with

    pip install git+https://github.com/OMS-NetZero/FAIR.git@c_plus_e

I never seem to understand how these different options in `setup.py` and `MANIFEST.in` are supposed to work, but this worked for me ...