### PR TITLE
re-add requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=1.4
+ipykernel
+nbsphinx


### PR DESCRIPTION
ReadTheDocs build failing, possibly due to requirements.txt being deleted.