### PR TITLE
adds common classes for Emissions, Concentrations, Forcings

### DIFF
--- a/fair/RCPs/rcp26.py
+++ b/fair/RCPs/rcp26.py
@@ -5,128 +5,20 @@
 # import rcp3pd
 # rcp3pd.Emissions.co2
 
-import numpy as np
 import os
+
+from . import types
+
+
 emissions_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP3PD_EMISSIONS.csv')
 concentrations_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP3PD_MIDYEAR_CONCENTRATIONS.csv')
 forcing_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP3PD_MIDYEAR_RADFORCING.csv')
-aviNOx_filename = os.path.join(
-    os.path.dirname(__file__), 'data/aviNOx_fraction.csv')
-fossilCH4_filename = os.path.join(
-    os.path.dirname(__file__), 'data/fossilCH4_fraction.csv')
 
-aviNOx_frac = np.loadtxt(aviNOx_filename, skiprows=5, usecols=(1,),
-    delimiter=',')
-fossilCH4_frac = np.loadtxt(fossilCH4_filename, skiprows=5, usecols=(1,),
-    delimiter=',')
+Emissions = types.Emissions(filename=emissions_filename)
 
-class Emissions:
-    emissions = np.loadtxt(emissions_filename, skiprows=37, delimiter=',')
-    year      = emissions[:,0]
-    co2_fossil= emissions[:,1]
-    co2_land  = emissions[:,2]
-    co2       = np.sum(emissions[:,1:3],axis=1)
-    ch4       = emissions[:,3]
-    n2o       = emissions[:,4]
-    sox       = emissions[:,5]
-    co        = emissions[:,6]
-    nmvoc     = emissions[:,7]
-    nox       = emissions[:,8]
-    bc        = emissions[:,9]
-    oc        = emissions[:,10]
-    nh3       = emissions[:,11]
-    cf4       = emissions[:,12]
-    c2f6      = emissions[:,13]
-    c6f14     = emissions[:,14]
-    hfc23     = emissions[:,15]
-    hfc32     = emissions[:,16]
-    hfc43_10  = emissions[:,17]
-    hfc125    = emissions[:,18]
-    hfc134a   = emissions[:,19]
-    hfc143a   = emissions[:,20]
-    hfc227ea  = emissions[:,21]
-    hfc245fa  = emissions[:,22]
-    sf6       = emissions[:,23]
-    cfc11     = emissions[:,24]
-    cfc12     = emissions[:,25]
-    cfc113    = emissions[:,26]
-    cfc114    = emissions[:,27]
-    cfc115    = emissions[:,28]
-    carb_tet  = emissions[:,29]
-    mcf       = emissions[:,30]
-    hcfc22    = emissions[:,31]
-    hcfc141b  = emissions[:,32]
-    hcfc142b  = emissions[:,33]
-    halon1211 = emissions[:,34]
-    halon1202 = emissions[:,35]
-    halon1301 = emissions[:,36]
-    halon2402 = emissions[:,37]
-    ch3br     = emissions[:,38]
-    ch3cl     = emissions[:,39]
+Concentrations = types.Concentrations(filename=concentrations_filename, skiprows=39)
 
-
-class Concentrations:
-    concentrations = np.loadtxt(concentrations_filename, skiprows=39,
-      delimiter=',')
-    year       = concentrations[:,0]
-    co2eq      = concentrations[:,1]
-    kyotoco2eq = concentrations[:,2]
-    co2        = concentrations[:,3]
-    ch4        = concentrations[:,4]
-    n2o        = concentrations[:,5]
-    fgassum    = concentrations[:,6]
-    mhalosum   = concentrations[:,7]
-    cf4        = concentrations[:,8]
-    c2f6       = concentrations[:,9]
-    c6f14      = concentrations[:,10]
-    hfc23      = concentrations[:,11]
-    hfc32      = concentrations[:,12]
-    hfc43_10   = concentrations[:,13]
-    hfc125     = concentrations[:,14]
-    hfc134a    = concentrations[:,15]
-    hfc143a    = concentrations[:,16]
-    hfc227ea   = concentrations[:,17]
-    hfc245fa   = concentrations[:,18]
-    sf6        = concentrations[:,19]
-    cfc11      = concentrations[:,20]
-    cfc12      = concentrations[:,21]
-    cfc113     = concentrations[:,22]
-    cfc114     = concentrations[:,23]
-    cfc115     = concentrations[:,24]
-    carb_tet   = concentrations[:,25]
-    mcf        = concentrations[:,26]
-    hcfc22     = concentrations[:,27]
-    hcfc141b   = concentrations[:,28]
-    hcfc142b   = concentrations[:,29]
-    halon1211  = concentrations[:,30]
-    halon1202  = concentrations[:,31]
-    halon1301  = concentrations[:,32]
-    halon2402  = concentrations[:,33]
-    ch3br      = concentrations[:,34]
-    ch3cl      = concentrations[:,35]    
-    
-    
-class Forcing:
-    forcing   = np.loadtxt(forcing_filename, skiprows=59, delimiter=',')
-    year      = forcing[:,0]
-    total     = forcing[:,1]
-    volcanic  = forcing[:,2]
-    solar     = forcing[:,3]
-    ghg       = forcing[:,5]
-    co2       = forcing[:,8]
-    ch4       = forcing[:,9]
-    n2o       = forcing[:,10]
-    fgas      = forcing[:,11]
-    halo      = forcing[:,12]
-    aero      = forcing[:,41]
-    cloud     = forcing[:,48]
-    strato3   = forcing[:,49]
-    tropo3    = forcing[:,50]
-    stwv      = forcing[:,51]
-    dust      = forcing[:,47]
-    landuse   = forcing[:,52]
-    bcsnow    = forcing[:,53]
-
+Forcing = types.Forcing(filename=forcing_filename)

--- a/fair/RCPs/rcp45.py
+++ b/fair/RCPs/rcp45.py
@@ -5,130 +5,20 @@
 # import rcp45
 # rcp45.Emissions.co2
 
-import numpy as np
 import os
+
+from . import types
+
+
 emissions_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP45_EMISSIONS.csv')
 concentrations_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP45_MIDYEAR_CONCENTRATIONS.csv')
 forcing_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP45_MIDYEAR_RADFORCING.csv')
-aviNOx_filename = os.path.join(
-    os.path.dirname(__file__), 'data/aviNOx_fraction.csv')
-fossilCH4_filename = os.path.join(
-    os.path.dirname(__file__), 'data/fossilCH4_fraction.csv')
 
-aviNOx_frac = np.loadtxt(aviNOx_filename, skiprows=5, usecols=(2,),
-    delimiter=',')
-fossilCH4_frac = np.loadtxt(fossilCH4_filename, skiprows=5, usecols=(2,),
-    delimiter=',')
+Emissions = types.Emissions(filename=emissions_filename)
 
-class Emissions:
-    emissions = np.loadtxt(emissions_filename, skiprows=37, delimiter=',')
-    year      = emissions[:,0]
-    co2_fossil= emissions[:,1]
-    co2_land  = emissions[:,2]
-    co2       = np.sum(emissions[:,1:3],axis=1)
-    ch4       = emissions[:,3]
-    n2o       = emissions[:,4]
-    sox       = emissions[:,5]
-    co        = emissions[:,6]
-    nmvoc     = emissions[:,7]
-    nox       = emissions[:,8]
-    bc        = emissions[:,9]
-    oc        = emissions[:,10]
-    nh3       = emissions[:,11]
-    cf4       = emissions[:,12]
-    c2f6      = emissions[:,13]
-    c6f14     = emissions[:,14]
-    hfc23     = emissions[:,15]
-    hfc32     = emissions[:,16]
-    hfc43_10  = emissions[:,17]
-    hfc125    = emissions[:,18]
-    hfc134a   = emissions[:,19]
-    hfc143a   = emissions[:,20]
-    hfc227ea  = emissions[:,21]
-    hfc245fa  = emissions[:,22]
-    sf6       = emissions[:,23]
-    cfc11     = emissions[:,24]
-    cfc12     = emissions[:,25]
-    cfc113    = emissions[:,26]
-    cfc114    = emissions[:,27]
-    cfc115    = emissions[:,28]
-    carb_tet  = emissions[:,29]
-    mcf       = emissions[:,30]
-    hcfc22    = emissions[:,31]
-    hcfc141b  = emissions[:,32]
-    hcfc142b  = emissions[:,33]
-    halon1211 = emissions[:,34]
-    halon1202 = emissions[:,35]
-    halon1301 = emissions[:,36]
-    halon2402 = emissions[:,37]
-    ch3br     = emissions[:,38]
-    ch3cl     = emissions[:,39]
+Concentrations = types.Concentrations(filename=concentrations_filename)
 
-
-class Concentrations:
-    concentrations = np.loadtxt(concentrations_filename, skiprows=38,
-      delimiter=',')
-    gas_indices= np.concatenate(([3,4,5], np.arange(8,36)))
-    gases      = concentrations[:,gas_indices]
-    year       = concentrations[:,0]
-    co2eq      = concentrations[:,1]
-    kyotoco2eq = concentrations[:,2]
-    co2        = concentrations[:,3]
-    ch4        = concentrations[:,4]
-    n2o        = concentrations[:,5]
-    fgassum    = concentrations[:,6]
-    mhalosum   = concentrations[:,7]
-    cf4        = concentrations[:,8]
-    c2f6       = concentrations[:,9]
-    c6f14      = concentrations[:,10]
-    hfc23      = concentrations[:,11]
-    hfc32      = concentrations[:,12]
-    hfc43_10   = concentrations[:,13]
-    hfc125     = concentrations[:,14]
-    hfc134a    = concentrations[:,15]
-    hfc143a    = concentrations[:,16]
-    hfc227ea   = concentrations[:,17]
-    hfc245fa   = concentrations[:,18]
-    sf6        = concentrations[:,19]
-    cfc11      = concentrations[:,20]
-    cfc12      = concentrations[:,21]
-    cfc113     = concentrations[:,22]
-    cfc114     = concentrations[:,23]
-    cfc115     = concentrations[:,24]
-    carb_tet   = concentrations[:,25]
-    mcf        = concentrations[:,26]
-    hcfc22     = concentrations[:,27]
-    hcfc141b   = concentrations[:,28]
-    hcfc142b   = concentrations[:,29]
-    halon1211  = concentrations[:,30]
-    halon1202  = concentrations[:,31]
-    halon1301  = concentrations[:,32]
-    halon2402  = concentrations[:,33]
-    ch3br      = concentrations[:,34]
-    ch3cl      = concentrations[:,35]
-
-    
-class Forcing:
-    forcing   = np.loadtxt(forcing_filename, skiprows=59, delimiter=',')
-    year      = forcing[:,0]
-    total     = forcing[:,1]
-    volcanic  = forcing[:,2]
-    solar     = forcing[:,3]
-    ghg       = forcing[:,5]
-    co2       = forcing[:,8]
-    ch4       = forcing[:,9]
-    n2o       = forcing[:,10]
-    fgas      = forcing[:,11]
-    halo      = forcing[:,12]
-    aero      = forcing[:,41]
-    cloud     = forcing[:,48]
-    strato3   = forcing[:,49]
-    tropo3    = forcing[:,50]
-    stwv      = forcing[:,51]
-    dust      = forcing[:,47]
-    landuse   = forcing[:,52]
-    bcsnow    = forcing[:,53]
-
+Forcing = types.Forcing(filename=forcing_filename)

--- a/fair/RCPs/rcp60.py
+++ b/fair/RCPs/rcp60.py
@@ -5,128 +5,20 @@
 # import rcp6
 # rcp6.Emissions.co2
 
-import numpy as np
 import os
+
+from . import types
+
+
 emissions_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP6_EMISSIONS.csv')
 concentrations_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP6_MIDYEAR_CONCENTRATIONS.csv')
 forcing_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP6_MIDYEAR_RADFORCING.csv')
-aviNOx_filename = os.path.join(
-    os.path.dirname(__file__), 'data/aviNOx_fraction.csv')
-fossilCH4_filename = os.path.join(
-    os.path.dirname(__file__), 'data/fossilCH4_fraction.csv')
 
-aviNOx_frac = np.loadtxt(aviNOx_filename, skiprows=5, usecols=(3,),
-    delimiter=',')
-fossilCH4_frac = np.loadtxt(fossilCH4_filename, skiprows=5, usecols=(3,),
-    delimiter=',')
+Emissions = types.Emissions(filename=emissions_filename)
 
-class Emissions:
-    emissions = np.loadtxt(emissions_filename, skiprows=37, delimiter=',')
-    year      = emissions[:,0]
-    co2_fossil= emissions[:,1]
-    co2_land  = emissions[:,2]
-    co2       = np.sum(emissions[:,1:3],axis=1)
-    ch4       = emissions[:,3]
-    n2o       = emissions[:,4]
-    sox       = emissions[:,5]
-    co        = emissions[:,6]
-    nmvoc     = emissions[:,7]
-    nox       = emissions[:,8]
-    bc        = emissions[:,9]
-    oc        = emissions[:,10]
-    nh3       = emissions[:,11]
-    cf4       = emissions[:,12]
-    c2f6      = emissions[:,13]
-    c6f14     = emissions[:,14]
-    hfc23     = emissions[:,15]
-    hfc32     = emissions[:,16]
-    hfc43_10  = emissions[:,17]
-    hfc125    = emissions[:,18]
-    hfc134a   = emissions[:,19]
-    hfc143a   = emissions[:,20]
-    hfc227ea  = emissions[:,21]
-    hfc245fa  = emissions[:,22]
-    sf6       = emissions[:,23]
-    cfc11     = emissions[:,24]
-    cfc12     = emissions[:,25]
-    cfc113    = emissions[:,26]
-    cfc114    = emissions[:,27]
-    cfc115    = emissions[:,28]
-    carb_tet  = emissions[:,29]
-    mcf       = emissions[:,30]
-    hcfc22    = emissions[:,31]
-    hcfc141b  = emissions[:,32]
-    hcfc142b  = emissions[:,33]
-    halon1211 = emissions[:,34]
-    halon1202 = emissions[:,35]
-    halon1301 = emissions[:,36]
-    halon2402 = emissions[:,37]
-    ch3br     = emissions[:,38]
-    ch3cl     = emissions[:,39]
+Concentrations = types.Concentrations(filename=concentrations_filename, skiprows=39)
 
-
-class Concentrations:
-    concentrations = np.loadtxt(concentrations_filename, skiprows=39,
-      delimiter=',')
-    year       = concentrations[:,0]
-    co2eq      = concentrations[:,1]
-    kyotoco2eq = concentrations[:,2]
-    co2        = concentrations[:,3]
-    ch4        = concentrations[:,4]
-    n2o        = concentrations[:,5]
-    fgassum    = concentrations[:,6]
-    mhalosum   = concentrations[:,7]
-    cf4        = concentrations[:,8]
-    c2f6       = concentrations[:,9]
-    c6f14      = concentrations[:,10]
-    hfc23      = concentrations[:,11]
-    hfc32      = concentrations[:,12]
-    hfc43_10   = concentrations[:,13]
-    hfc125     = concentrations[:,14]
-    hfc134a    = concentrations[:,15]
-    hfc143a    = concentrations[:,16]
-    hfc227ea   = concentrations[:,17]
-    hfc245fa   = concentrations[:,18]
-    sf6        = concentrations[:,19]
-    cfc11      = concentrations[:,20]
-    cfc12      = concentrations[:,21]
-    cfc113     = concentrations[:,22]
-    cfc114     = concentrations[:,23]
-    cfc115     = concentrations[:,24]
-    carb_tet   = concentrations[:,25]
-    mcf        = concentrations[:,26]
-    hcfc22     = concentrations[:,27]
-    hcfc141b   = concentrations[:,28]
-    hcfc142b   = concentrations[:,29]
-    halon1211  = concentrations[:,30]
-    halon1202  = concentrations[:,31]
-    halon1301  = concentrations[:,32]
-    halon2402  = concentrations[:,33]
-    ch3br      = concentrations[:,34]
-    ch3cl      = concentrations[:,35]        
-    
-    
-class Forcing:
-    forcing   = np.loadtxt(forcing_filename, skiprows=59, delimiter=',')
-    year      = forcing[:,0]
-    total     = forcing[:,1]
-    volcanic  = forcing[:,2]
-    solar     = forcing[:,3]
-    ghg       = forcing[:,5]
-    co2       = forcing[:,8]
-    ch4       = forcing[:,9]
-    n2o       = forcing[:,10]
-    fgas      = forcing[:,11]
-    halo      = forcing[:,12]
-    aero      = forcing[:,41]
-    cloud     = forcing[:,48]
-    strato3   = forcing[:,49]
-    tropo3    = forcing[:,50]
-    stwv      = forcing[:,51]
-    dust      = forcing[:,47]
-    landuse   = forcing[:,52]
-    bcsnow    = forcing[:,53]
-
+Forcing = types.Forcing(filename=forcing_filename)

--- a/fair/RCPs/rcp85.py
+++ b/fair/RCPs/rcp85.py
@@ -5,128 +5,20 @@
 # import rcp85
 # rcp85.Emissions.co2
 
-import numpy as np
 import os
+
+from . import types
+
+
 emissions_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP85_EMISSIONS.csv')
 concentrations_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP85_MIDYEAR_CONCENTRATIONS.csv')
 forcing_filename = os.path.join(
     os.path.dirname(__file__), 'data/RCP85_MIDYEAR_RADFORCING.csv')
-aviNOx_filename = os.path.join(
-    os.path.dirname(__file__), 'data/aviNOx_fraction.csv')
-fossilCH4_filename = os.path.join(
-    os.path.dirname(__file__), 'data/fossilCH4_fraction.csv')
 
-aviNOx_frac = np.loadtxt(aviNOx_filename, skiprows=5, usecols=(4,),
-    delimiter=',')
-fossilCH4_frac = np.loadtxt(fossilCH4_filename, skiprows=5, usecols=(4,),
-    delimiter=',')
+Emissions = types.Emissions(filename=emissions_filename)
 
-class Emissions:
-    emissions = np.loadtxt(emissions_filename, skiprows=37, delimiter=',')
-    year      = emissions[:,0]
-    co2_fossil= emissions[:,1]
-    co2_land  = emissions[:,2]
-    co2       = np.sum(emissions[:,1:3],axis=1)
-    ch4       = emissions[:,3]
-    n2o       = emissions[:,4]
-    sox       = emissions[:,5]
-    co        = emissions[:,6]
-    nmvoc     = emissions[:,7]
-    nox       = emissions[:,8]
-    bc        = emissions[:,9]
-    oc        = emissions[:,10]
-    nh3       = emissions[:,11]
-    cf4       = emissions[:,12]
-    c2f6      = emissions[:,13]
-    c6f14     = emissions[:,14]
-    hfc23     = emissions[:,15]
-    hfc32     = emissions[:,16]
-    hfc43_10  = emissions[:,17]
-    hfc125    = emissions[:,18]
-    hfc134a   = emissions[:,19]
-    hfc143a   = emissions[:,20]
-    hfc227ea  = emissions[:,21]
-    hfc245fa  = emissions[:,22]
-    sf6       = emissions[:,23]
-    cfc11     = emissions[:,24]
-    cfc12     = emissions[:,25]
-    cfc113    = emissions[:,26]
-    cfc114    = emissions[:,27]
-    cfc115    = emissions[:,28]
-    carb_tet  = emissions[:,29]
-    mcf       = emissions[:,30]
-    hcfc22    = emissions[:,31]
-    hcfc141b  = emissions[:,32]
-    hcfc142b  = emissions[:,33]
-    halon1211 = emissions[:,34]
-    halon1202 = emissions[:,35]
-    halon1301 = emissions[:,36]
-    halon2402 = emissions[:,37]
-    ch3br     = emissions[:,38]
-    ch3cl     = emissions[:,39]
+Concentrations = types.Concentrations(filename=concentrations_filename, skiprows=39)
 
-
-class Concentrations:
-    concentrations = np.loadtxt(concentrations_filename, skiprows=39,
-      delimiter=',')
-    year       = concentrations[:,0]
-    co2eq      = concentrations[:,1]
-    kyotoco2eq = concentrations[:,2]
-    co2        = concentrations[:,3]
-    ch4        = concentrations[:,4]
-    n2o        = concentrations[:,5]
-    fgassum    = concentrations[:,6]
-    mhalosum   = concentrations[:,7]
-    cf4        = concentrations[:,8]
-    c2f6       = concentrations[:,9]
-    c6f14      = concentrations[:,10]
-    hfc23      = concentrations[:,11]
-    hfc32      = concentrations[:,12]
-    hfc43_10   = concentrations[:,13]
-    hfc125     = concentrations[:,14]
-    hfc134a    = concentrations[:,15]
-    hfc143a    = concentrations[:,16]
-    hfc227ea   = concentrations[:,17]
-    hfc245fa   = concentrations[:,18]
-    sf6        = concentrations[:,19]
-    cfc11      = concentrations[:,20]
-    cfc12      = concentrations[:,21]
-    cfc113     = concentrations[:,22]
-    cfc114     = concentrations[:,23]
-    cfc115     = concentrations[:,24]
-    carb_tet   = concentrations[:,25]
-    mcf        = concentrations[:,26]
-    hcfc22     = concentrations[:,27]
-    hcfc141b   = concentrations[:,28]
-    hcfc142b   = concentrations[:,29]
-    halon1211  = concentrations[:,30]
-    halon1202  = concentrations[:,31]
-    halon1301  = concentrations[:,32]
-    halon2402  = concentrations[:,33]
-    ch3br      = concentrations[:,34]
-    ch3cl      = concentrations[:,35]    
-
-    
-class Forcing:
-    forcing   = np.loadtxt(forcing_filename, skiprows=59, delimiter=',')
-    year      = forcing[:,0]
-    total     = forcing[:,1]
-    volcanic  = forcing[:,2]
-    solar     = forcing[:,3]
-    ghg       = forcing[:,5]
-    co2       = forcing[:,8]
-    ch4       = forcing[:,9]
-    n2o       = forcing[:,10]
-    fgas      = forcing[:,11]
-    halo      = forcing[:,12]
-    aero      = forcing[:,41]
-    cloud     = forcing[:,48]
-    strato3   = forcing[:,49]
-    tropo3    = forcing[:,50]
-    stwv      = forcing[:,51]
-    dust      = forcing[:,47]
-    landuse   = forcing[:,52]
-    bcsnow    = forcing[:,53]
-
+Forcing = types.Forcing(filename=forcing_filename)

--- a/fair/RCPs/types.py
+++ b/fair/RCPs/types.py
@@ -1,0 +1,424 @@
+# Convenience classes for loading in rcp datasets
+
+import numpy as np
+
+
+class Emissions(object):
+
+    def __init__(self, skiprows=37, **kwargs):
+        self._filename =  kwargs.get('filename')
+        self.emissions = np.loadtxt(self._filename, skiprows=skiprows, delimiter=',')
+
+    def __repr__(self):
+        return '<{} with source \'{}\'>'.format(self.__class__.__name__, self._filename)
+
+    @property
+    def year(self):
+        return self.emissions[:,0]
+
+    @property
+    def co2_fossil(self):
+        return self.emissions[:,1]
+
+    @property
+    def co2_land(self):
+        return self.emissions[:,2]
+
+    @property
+    def co2(self):
+        return np.sum(self.emissions[:,1:3], axis=1)
+
+    @property
+    def ch4(self):
+        return self.emissions[:,3]
+
+    @property
+    def n2o(self):
+        return self.emissions[:,4]
+
+    @property
+    def sox(self):
+        return self.emissions[:,5]
+
+    @property
+    def co(self):
+        return self.emissions[:,6]
+
+    @property
+    def nmvoc(self):
+        return self.emissions[:,7]
+
+    @property
+    def nox(self):
+        return self.emissions[:,8]
+
+    @property
+    def bc(self):
+        return self.emissions[:,9]
+
+    @property
+    def oc(self):
+        return self.emissions[:,10]
+
+    @property
+    def nh3(self):
+        return self.emissions[:,11]
+
+    @property
+    def cf4(self):
+        return self.emissions[:,12]
+
+    @property
+    def c2f6(self):
+        return self.emissions[:,13]
+
+    @property
+    def c6f14(self):
+        return self.emissions[:,14]
+
+    @property
+    def hfc23(self):
+        return self.emissions[:,15]
+
+    @property
+    def hfc32(self):
+        return self.emissions[:,16]
+
+    @property
+    def hfc43_10(self):
+        return self.emissions[:,17]
+
+    @property
+    def hfc125(self):
+        return self.emissions[:,18]
+
+    @property
+    def hfc134a(self):
+        return self.emissions[:,19]
+
+    @property
+    def hfc143a(self):
+        return self.emissions[:,20]
+
+    @property
+    def hfc227ea(self):
+        return self.emissions[:,21]
+
+    @property
+    def hfc245fa(self):
+        return self.emissions[:,22]
+
+    @property
+    def sf6(self):
+        return self.emissions[:,23]
+
+    @property
+    def cfc11(self):
+        return self.emissions[:,24]
+
+    @property
+    def cfc12(self):
+        return self.emissions[:,25]
+
+    @property
+    def cfc113(self):
+        return self.emissions[:,26]
+
+    @property
+    def cfc114(self):
+        return self.emissions[:,27]
+
+    @property
+    def cfc115(self):
+        return self.emissions[:,28]
+
+    @property
+    def carb_tet(self):
+        return self.emissions[:,29]
+
+    @property
+    def mcf(self):
+        return self.emissions[:,30]
+
+    @property
+    def hcfc22(self):
+        return self.emissions[:,31]
+
+    @property
+    def hcfc141b(self):
+        return self.emissions[:,32]
+
+    @property
+    def hcfc142b(self):
+        return self.emissions[:,33]
+
+    @property
+    def halon1211(self):
+        return self.emissions[:,34]
+
+    @property
+    def halon1202(self):
+        return self.emissions[:,35]
+
+    @property
+    def halon1301(self):
+        return self.emissions[:,36]
+
+    @property
+    def halon2402(self):
+        return self.emissions[:,37]
+
+    @property
+    def ch3br(self):
+        return self.emissions[:,38]
+
+    @property
+    def ch3cl(self):
+        return self.emissions[:,39]
+
+
+class Concentrations(object):
+
+    def __init__(self, **kwargs):
+        self._filename = kwargs.get('filename')
+        skiprows = kwargs.get('skiprows', 38)
+        self.concentrations = np.loadtxt(self._filename, skiprows=skiprows, delimiter=',')
+
+    def __repr__(self):
+        return '<{} with source \'{}\'>'.format(self.__class__.__name__, self._filename)
+
+    @property
+    def gas_indices(self):
+        return np.concatenate(([3,4,5], np.arange(8,36)))
+
+    @property
+    def gases(self):
+        return self.concentrations[:,self.gas_indices]
+
+    @property
+    def year(self):
+        return self.concentrations[:,0]
+
+    @property
+    def co2eq(self):
+        return self.concentrations[:,1]
+
+    @property
+    def kyotoco2eq(self):
+        return self.concentrations[:,2]
+
+    @property
+    def co2(self):
+        return self.concentrations[:,3]
+
+    @property
+    def ch4(self):
+        return self.concentrations[:,4]
+
+    @property
+    def n2o(self):
+        return self.concentrations[:,5]
+
+    @property
+    def fgassum(self):
+        return self.concentrations[:,6]
+
+    @property
+    def mhalosum(self):
+        return self.concentrations[:,7]
+
+    @property
+    def cf4(self):
+        return self.concentrations[:,8]
+
+    @property
+    def c2f6(self):
+        return self.concentrations[:,9]
+
+    @property
+    def c6f14(self):
+        return self.concentrations[:,10]
+
+    @property
+    def hfc23(self):
+        return self.concentrations[:,11]
+
+    @property
+    def hfc32(self):
+        return self.concentrations[:,12]
+
+    @property
+    def hfc43_10(self):
+        return self.concentrations[:,13]
+
+    @property
+    def hfc125(self):
+        return self.concentrations[:,14]
+
+    @property
+    def hfc134a(self):
+        return self.concentrations[:,15]
+
+    @property
+    def hfc143a(self):
+        return self.concentrations[:,16]
+
+    @property
+    def hfc227ea(self):
+        return self.concentrations[:,17]
+
+    @property
+    def hfc245fa(self):
+        return self.concentrations[:,18]
+
+    @property
+    def sf6(self):
+        return self.concentrations[:,19]
+
+    @property
+    def cfc11(self):
+        return self.concentrations[:,20]
+
+    @property
+    def cfc12(self):
+        return self.concentrations[:,21]
+
+    @property
+    def cfc113(self):
+        return self.concentrations[:,22]
+
+    @property
+    def cfc114(self):
+        return self.concentrations[:,23]
+
+    @property
+    def cfc115(self):
+        return self.concentrations[:,24]
+
+    @property
+    def carb_tet(self):
+        return self.concentrations[:,25]
+
+    @property
+    def mcf(self):
+        return self.concentrations[:,26]
+
+    @property
+    def hcfc22(self):
+        return self.concentrations[:,27]
+
+    @property
+    def hcfc141b(self):
+        return self.concentrations[:,28]
+
+    @property
+    def hcfc142b(self):
+        return self.concentrations[:,29]
+
+    @property
+    def halon1211(self):
+        return self.concentrations[:,30]
+
+    @property
+    def halon1202(self):
+        return self.concentrations[:,31]
+
+    @property
+    def halon1301(self):
+        return self.concentrations[:,32]
+
+    @property
+    def halon2402(self):
+        return self.concentrations[:,33]
+
+    @property
+    def ch3br(self):
+        return self.concentrations[:,34]
+
+    @property
+    def ch3cl(self):
+        return self.concentrations[:,35]
+
+
+
+class Forcing(object):
+    def __init__(self, skiprows=59, **kwargs):
+        self._filename = kwargs.get('filename')
+        self.forcing = np.loadtxt(self._filename, skiprows=skiprows, delimiter=',')
+
+    def __repr__(self):
+        return '<{} with source \'{}\'>'.format(self.__class__.__name__, self._filename)
+
+    @property
+    def year(self):
+        return self.forcing[:,0]
+
+    @property
+    def total(self):
+        return self.forcing[:,1]
+
+    @property
+    def volcanic(self):
+        return self.forcing[:,2]
+
+    @property
+    def solar(self):
+        return self.forcing[:,3]
+
+    @property
+    def ghg(self):
+        return self.forcing[:,5]
+
+    @property
+    def co2(self):
+        return self.forcing[:,8]
+
+    @property
+    def ch4(self):
+        return self.forcing[:,9]
+
+    @property
+    def n2o(self):
+        return self.forcing[:,10]
+
+    @property
+    def fgas(self):
+        return self.forcing[:,11]
+
+    @property
+    def halo(self):
+        return self.forcing[:,12]
+
+    @property
+    def aero(self):
+        return self.forcing[:,41]
+
+    @property
+    def cloud(self):
+        return self.forcing[:,48]
+
+    @property
+    def strato3(self):
+        return self.forcing[:,49]
+
+    @property
+    def tropo3(self):
+        return self.forcing[:,50]
+
+    @property
+    def stwv(self):
+        return self.forcing[:,51]
+
+    @property
+    def dust(self):
+        return self.forcing[:,47]
+
+    @property
+    def landuse(self):
+        return self.forcing[:,52]
+
+    @property
+    def bcsnow(self):
+        return self.forcing[:,53]
+
+


### PR DESCRIPTION
the classes simplify the rcp_.py files while providing a consistent interface to the data when ingesting arbitrary rcp csv files (i.e. useful in cases where you don't want or need to import all three Emissions/Concentrations/Forcings)

also useful in cases where you need to override specific property behavior (i.e. scaling or reformatting some specific property dynamically)
```python
from fair.RCPs import types

 class SpecialForcing(types.Forcing):                              
     def __init__(self, *args, **kwargs):
         super(SpecialForcing, self).__init__(*args, **kwargs)

     @property
     def year(self):
         return map(int, super(SpecialForcing, self).year.tolist())
```
this subclassed `Forcing` would no longer emit an ndarray for years, but instead a simple python list of `int`s. This is an pretty contrived example, but i think fairly illustrative.

The goal here was to maintain api parity while adding some minor functionality. Tests pass at the same rate as before. 

specific additions:
- `._filename` is exposed
- each instance's `__repr__` exposes an Emission/Concentration/Forcing's source filename as well.

# Pull request

Please confirm that this pull request has done the following:

- [x] Tests added (tests pass at same rate as before)
- [ ] Documentation added (where applicable)
- [ ] Example added (either to an existing notebook or as a new notebook, where applicable)
- [ ] Description in ``CHANGELOG.rst`` added

## Adding to CHANGELOG.rst

Please add a single line in the changelog notes similar to one of the following:

```
- (`#XX <http://link-to-pr.com>`_) Added feature which does something
- (`#XX <http://link-to-pr.com>`_) Fixed bug identified in (`#XX <http://link-to-issue.com>`_)
```
