### PR TITLE
Add Meinshausen et al 2019 forcing as an option

### DIFF
--- a/fair/forcing/ghg.py
+++ b/fair/forcing/ghg.py
@@ -4,6 +4,60 @@ import numpy as np
 
 from ..constants import radeff
 
+
+def meinshausen(
+    C,
+    Cpi=np.array([277.15, 731.41, 273.87]),
+    a1=-2.4785e-07, b1=0.00075906, c1=-0.0021492, d1 = 5.2488,
+    a2=-0.00034197, b2 = 0.00025455, c2 =-0.00024357, d2 = 0.12173,
+    a3 =-8.9603e-05, b3 = -0.00012462, d3 = 0.045194,
+    F2x=3.71, scale_F2x=True
+    ):
+    """Modified Etminan relationship from Meinshausen et al 2019
+    https://gmd.copernicus.org/preprints/gmd-2019-222/gmd-2019-222.pdf
+    table 3
+
+    Inputs:
+        C: [CO2, CH4, N2O] concentrations, [ppm, ppb, ppb]
+
+    Keywords:
+        Cpi: pre-industrial [CO2, CH4, N2O] concentrations. Should use defaults
+        a1, b1, c1, d1, a2, b2, c2, d2, a3, b3, d3: coefficients
+
+    Returns:
+        3-element array of radiative forcing: [F_CO2, F_CH4, F_N2O]
+
+    """
+    # Tune the coefficient of CO2 forcing to acheive desired F2x, using
+    # pre-industrial CO2 and N2O. F2x_etminan ~= 3.801.
+    scaleCO2 = 1
+    if scale_F2x:
+        F2x_etminan = (
+          -2.4e-7*Cpi[0]**2 + 7.2e-4*Cpi[0] - 2.1e-4*Cpi[2] + 5.36) * np.log(2)
+        scaleCO2 = F2x/F2x_etminan
+
+    F = np.zeros(3)
+
+    # CO2
+    Camax = Cpi[0] - b1/(2*a1)
+    if Cpi[0] < C[0] <= Camax: # the most likely case
+        alphap = d1 + a1*(C[0] - Cpi[0])**2 + b1*(C[0] - Cpi[0])
+    elif C[0] <= Cpi[0]:
+        alphap = d1
+    else:
+        alphap = d1 - b1**2-(4*a1)
+    alphaN2O = c1*np.sqrt(C[2])
+    F[0] = (alphap + alphaN2O) * np.log(C[0]/Cpi[0]) * scaleCO2
+
+    # CH4
+    F[1] = (a3*np.sqrt(C[1]) + b3*np.sqrt(C[2]) + d3) * (np.sqrt(C[1]) - np.sqrt(Cpi[1]))
+
+    # N2O
+    F[2] = (a2*np.sqrt(C[0]) + b2*np.sqrt(C[2]) + c2*np.sqrt(C[1])) * (np.sqrt(C[2]) - np.sqrt(Cpi[2]))
+
+    return F
+
+
 def etminan(C, Cpi, F2x=3.71, scale_F2x=True):
     """Calculate the radiative forcing from CO2, CH4 and N2O.
 

--- a/fair/forcing/ghg.py
+++ b/fair/forcing/ghg.py
@@ -23,6 +23,8 @@ def meinshausen(
     Keywords:
         Cpi: pre-industrial [CO2, CH4, N2O] concentrations. Should use defaults
         a1, b1, c1, d1, a2, b2, c2, d2, a3, b3, d3: coefficients
+        F2x: radiative forcing from a doubling of CO2.
+        scale_F2x: boolean. Scale the calculated value to the specified F2x?
 
     Returns:
         3-element array of radiative forcing: [F_CO2, F_CH4, F_N2O]
@@ -45,7 +47,7 @@ def meinshausen(
     elif C[0] <= Cpi[0]:
         alphap = d1
     else:
-        alphap = d1 - b1**2-(4*a1)
+        alphap = d1 - b1**2/(4*a1)
     alphaN2O = c1*np.sqrt(C[2])
     F[0] = (alphap + alphaN2O) * np.log(C[0]/Cpi[0]) * scaleCO2
 
@@ -53,7 +55,7 @@ def meinshausen(
     F[1] = (a3*np.sqrt(C[1]) + b3*np.sqrt(C[2]) + d3) * (np.sqrt(C[1]) - np.sqrt(Cpi[1]))
 
     # N2O
-    F[2] = (a2*np.sqrt(C[0]) + b2*np.sqrt(C[2]) + c2*np.sqrt(C[1])) * (np.sqrt(C[2]) - np.sqrt(Cpi[2]))
+    F[2] = (a2*np.sqrt(C[0]) + b2*np.sqrt(C[2]) + c2*np.sqrt(C[1]) + d2) * (np.sqrt(C[2]) - np.sqrt(Cpi[2]))
 
     return F
 
@@ -72,6 +74,7 @@ def etminan(C, Cpi, F2x=3.71, scale_F2x=True):
 
     Keywords:
         F2x: radiative forcing from a doubling of CO2.
+        scale_F2x: boolean. Scale the calculated value to the specified F2x?
 
     Returns:
         3-element array of radiative forcing: [F_CO2, F_CH4, F_N2O]

--- a/fair/forward.py
+++ b/fair/forward.py
@@ -225,9 +225,12 @@ def fair_scm(
         elif ghg_forcing.lower()=="myhre":
             from .forcing.ghg import myhre as ghg
             if stwv_from_ch4==None: stwv_from_ch4=0.15
+        elif ghg_forcing.lower()=="meinshausen":
+            from .forcing.ghg import meinshausen as ghg
+            if stwv_from_ch4==None: stwv_from_ch4=0.12
         else:
             raise ValueError(
-              "ghg_forcing should be 'etminan' (default) or 'myhre'")
+              "ghg_forcing should be 'etminan' (default), 'meinshausen' or 'myhre'")
         # aerosol breakdown
         ariaci = np.zeros((nt,2))
             

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
         'matplotlib',
         'numpy>=1.14.5',
         'scipy>=0.19.0',
-        'pandas'
+        'pandas',
+        'scmdata'
     ],
     zip_safe=False,
     extras_require={

--- a/tests/unit/unit_test.py
+++ b/tests/unit/unit_test.py
@@ -421,3 +421,14 @@ def test_gir():
       emissions=rcp85.Emissions.emissions,
       gir_carbon_cycle=True
     )
+
+def test_meinshausen():
+    C1,F1,T1 = fair.forward.fair_scm(
+      emissions=rcp85.Emissions.emissions,
+      ghg_forcing="Meinshausen"
+    )
+    C2,F2,T2 = fair.forward.fair_scm(
+      emissions=rcp85.Emissions.emissions,
+      ghg_forcing="Etminan"
+    )
+    assert np.any(F1!=F2)


### PR DESCRIPTION
Addresses #72 

See section 2.7 and table 3 in https://gmd.copernicus.org/preprints/gmd-2019-222/gmd-2019-222.pdf

Etminan is still default but new behaviour can be activated with `ghg_forcing="meinshausen"`