### PR TITLE
Bugfix in inverse_fair_scm for scalar F_in

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 master
 ------
 
+(`#109 <https://github.com/OMS-NetZero/FAIR/pull/109>`_) Fixes error when running inverse_fair_scm with a scalar F_in value.
+
 v1.6.4
 ------
 

--- a/fair/inverse.py
+++ b/fair/inverse.py
@@ -197,7 +197,7 @@ def inverse_fair_scm(
         prescribed_forcing = False
     else:
         if np.isscalar(F_in):
-            F_in = np.ones(nt) * F_in
+            F = np.ones(nt) * F_in
         else:
             if len(F_in) != nt:
                 raise ValueError('F_in must be same size as C, which is '+nt)

--- a/tests/unit/unit_test.py
+++ b/tests/unit/unit_test.py
@@ -525,6 +525,11 @@ def test_inverse_millar_fin():
         F_in = rcp85.Forcing.total
     )
 
+def test_inverse_const_forcing():
+    emissions, Fe, Te = inverse_fair_scm(
+        C = rcp85.Concentrations.co2,
+        F_in = 0
+    )
 
 def test_thornhill_skeie():
     forcing = thornhill_skeie(


### PR DESCRIPTION
# Pull request

Hi OMS-NetZero team,

Very small pull request to fix a bug in `inverse_fair_scm`. If initialising with a scalar constant `F_in` the model fails with error: `UnboundLocalError: local variable 'F' referenced before assignment`.

The test included fails on current master, passes with this change.


Please confirm that this pull request has done the following:

- [x] Tests added
- [x] Documentation added (where applicable) - N/A
- [x] Example added (either to an existing notebook or as a new notebook, where applicable) -  N/A
- [x] Description in ``CHANGELOG.rst`` added

## Adding to CHANGELOG.rst

Please add a single line in the changelog notes similar to one of the following:

```
- (`#XX <http://link-to-pr.com>`_) Added feature which does something
- (`#XX <http://link-to-pr.com>`_) Fixed bug identified in (`#XX <http://link-to-issue.com>`_)
```
