### PR TITLE
Add functionality to fill values from a dataframe

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+v2.2.3
+------
+(`#173 <https://github.com/OMS-NetZero/FAIR/pull/173>`_) Enable users to fill values (e.g. for solar and volcanic forcing) directly from a pandas.DataFrame.
+
 v2.2.2
 ------
 

--- a/src/fair/fair.py
+++ b/src/fair/fair.py
@@ -93,7 +93,7 @@ class FAIR:
         self.temperature_prescribed = temperature_prescribed
 
     # attach fill_from methods
-    from .io.fill_from import fill_from_csv, fill_from_rcmip
+    from .io.fill_from import fill_from_csv, fill_from_rcmip, fill_from_pandas
     from .io.param_sets import override_defaults
 
     # must be a less cumbsersome way to code this

--- a/src/fair/fair.py
+++ b/src/fair/fair.py
@@ -93,7 +93,7 @@ class FAIR:
         self.temperature_prescribed = temperature_prescribed
 
     # attach fill_from methods
-    from .io.fill_from import fill_from_csv, fill_from_rcmip, fill_from_pandas
+    from .io.fill_from import fill_from_csv, fill_from_pandas, fill_from_rcmip
     from .io.param_sets import override_defaults
 
     # must be a less cumbsersome way to code this

--- a/src/fair/io/fill_from.py
+++ b/src/fair/io/fill_from.py
@@ -213,9 +213,7 @@ def fill_from_pandas(self, mode, df):
                 data_in = data_in.squeeze()
 
                 # interpolate from the supplied file to our desired timepoints
-                interpolator = interp1d(
-                    times_array, data_in, bounds_error=False
-                )
+                interpolator = interp1d(times_array, data_in, bounds_error=False)
                 data = interpolator(mode_time[mode])
 
                 # Parse and possibly convert unit in input to what FaIR wants

--- a/src/fair/io/fill_from.py
+++ b/src/fair/io/fill_from.py
@@ -181,7 +181,6 @@ def fill_from_pandas(self, mode, df):
     df : pd.DataFrame
         data for the infilling
     """
-
     mode_time = {
         "emissions": self.timepoints,
         "concentration": self.timebounds,

--- a/src/fair/io/fill_from.py
+++ b/src/fair/io/fill_from.py
@@ -158,71 +158,86 @@ def fill_from_csv(
         filename of effective radiative forcing to fill.
     """
     mode_options = {
-        "emissions": {
-            "file": emissions_file,
-            "time": self.timepoints,
-            "var": self.emissions,
-        },
-        "concentration": {
-            "file": concentration_file,
-            "time": self.timebounds,
-            "var": self.concentration,
-        },
-        "forcing": {"file": forcing_file, "time": self.timebounds, "var": self.forcing},
+        "emissions": {"file": emissions_file, "var": self.emissions},
+        "concentration": {"file": concentration_file, "var": self.concentration},
+        "forcing": {"file": forcing_file, "var": self.forcing},
     }
     for mode in mode_options:
         if mode_options[mode]["file"] is not None:
             df = pd.read_csv(mode_options[mode]["file"])
-            df.columns = df.columns.str.lower()
-            times = _check_csv(df, runmode=mode)  # list of strings
-            times_array = np.array(times, dtype=float)
+            self.fill_from_pandas(mode=mode, df=df)
 
-            for scenario in self.scenarios:
-                for specie in self.species:
-                    if self.properties_df.loc[specie, "input_mode"] == mode:
-                        # Grab raw emissions from dataframe
-                        data_in = df.loc[
-                            (df["scenario"] == scenario)
-                            & (df["variable"] == specie)
-                            & (df["region"].str.lower() == "world"),
-                            times[0] : times[-1],
-                        ].values
 
-                        # duplicates are ambigious and are an error
-                        if data_in.shape[0] > 1:
-                            raise DuplicateScenarioError(
-                                f"In {mode_options[mode]['file']} there are duplicate "
-                                f"rows for variable='{specie}, scenario='{scenario}'."
-                            )
-                        # now cast to 1D
-                        data_in = data_in.squeeze()
+def fill_from_pandas(self, mode, df):
+    """Fill emissions, concentration and/or forcing from a pandas DataFrame.
 
-                        # interpolate from the supplied file to our desired timepoints
-                        interpolator = interp1d(
-                            times_array, data_in, bounds_error=False
-                        )
-                        data = interpolator(mode_options[mode]["time"])
+    This method is part of the `FAIR` class. It uses self.scenarios and self.specie
+    to look up the scenario and variable to extract from the dataframe.
 
-                        # Parse and possibly convert unit in input to what FaIR wants
-                        unit = df.loc[
-                            (df["scenario"] == scenario)
-                            & (df["variable"] == specie)
-                            & (df["region"].str.lower() == "world"),
-                            "unit",
-                        ].values[0]
-                        is_ghg = self.properties_df.loc[specie, "greenhouse_gas"]
-                        if mode == "emissions":
-                            data = _emissions_unit_convert(data, unit, specie, is_ghg)
-                        elif mode == "concentration":
-                            data = _concentration_unit_convert(data, unit, specie)
+    Parameters
+    ----------
+    mode : str
+        can be "emissions", "concentration" or "forcing"
+    df : pd.DataFrame
+        data for the infilling
+    """
 
-                        # fill FaIR xarray
-                        fill(
-                            getattr(self, mode),
-                            data[:, None],
-                            specie=specie,
-                            scenario=scenario,
-                        )
+    mode_time = {
+        "emissions": self.timepoints,
+        "concentration": self.timebounds,
+        "forcing": self.timebounds,
+    }
+
+    df.columns = df.columns.str.lower()
+    times = _check_csv(df, runmode=mode)  # list of strings
+    times_array = np.array(times, dtype=float)
+
+    for scenario in self.scenarios:
+        for specie in self.species:
+            if self.properties_df.loc[specie, "input_mode"] == mode:
+                # Grab raw emissions from dataframe
+                data_in = df.loc[
+                    (df["scenario"] == scenario)
+                    & (df["variable"] == specie)
+                    & (df["region"].str.lower() == "world"),
+                    times[0] : times[-1],
+                ].values
+
+                # duplicates are ambigious and are an error
+                if data_in.shape[0] > 1:
+                    raise DuplicateScenarioError(
+                        f"Input data for {mode} contains duplicate "
+                        f"rows for variable='{specie}, scenario='{scenario}'."
+                    )
+                # now cast to 1D
+                data_in = data_in.squeeze()
+
+                # interpolate from the supplied file to our desired timepoints
+                interpolator = interp1d(
+                    times_array, data_in, bounds_error=False
+                )
+                data = interpolator(mode_time[mode])
+
+                # Parse and possibly convert unit in input to what FaIR wants
+                unit = df.loc[
+                    (df["scenario"] == scenario)
+                    & (df["variable"] == specie)
+                    & (df["region"].str.lower() == "world"),
+                    "unit",
+                ].values[0]
+                is_ghg = self.properties_df.loc[specie, "greenhouse_gas"]
+                if mode == "emissions":
+                    data = _emissions_unit_convert(data, unit, specie, is_ghg)
+                elif mode == "concentration":
+                    data = _concentration_unit_convert(data, unit, specie)
+
+                # fill FaIR xarray
+                fill(
+                    getattr(self, mode),
+                    data[:, None],
+                    specie=specie,
+                    scenario=scenario,
+                )
 
 
 # TO DO: make part of fill_from_csv


### PR DESCRIPTION
Hi @chrisroadmap,

It's nice to be here again on the FaIR github :)

Just a small pull-request to enable users to fill values directly from a pandas.DataFrame. My usecase is wanting to run multiple different scenarios (with names and emissions that can change depending on the run), while always using the same solar and volcanic forcing file. In my script, I would then read the file into a pandas.DataFrame, extend it according to which scenarios I have in the run, and then pass it into my fair model using the method I have added here `fill_from_pandas`. My update is backwards compatible; `fill_from_csv` works the same as before. I only moved code into a new method, which `fill_from_csv` now calls. Let me know if there's anything else you'd like me to do to get this merged.

Hope all is going well!

Sally
