### PR TITLE
change source of RCMIP datafiles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+master
+------
+(`#176 <https://github.com/OMS-NetZero/FAIR/pull/176>`_) Change source of external RCMIP datasets from Zenodo to Amazon AWS.
+
 v2.2.3
 ------
 (`#173 <https://github.com/OMS-NetZero/FAIR/pull/173>`_) Enable users to fill values (e.g. for solar and volcanic forcing) directly from a pandas.DataFrame.

--- a/src/fair/io/fill_from.py
+++ b/src/fair/io/fill_from.py
@@ -267,24 +267,24 @@ def fill_from_rcmip(self):
 
     emissions_file = pooch.retrieve(
         url=(
-            "https://zenodo.org/records/4589756/files/"
-            "rcmip-emissions-annual-means-v5-1-0.csv"
+            "https://rcmip-protocols-au.s3-ap-southeast-2.amazonaws.com/"
+            "v5.1.0/rcmip-emissions-annual-means-v5-1-0.csv"
         ),
         known_hash="md5:4044106f55ca65b094670e7577eaf9b3",
     )
 
     concentration_file = pooch.retrieve(
         url=(
-            "https://zenodo.org/records/4589756/files/"
-            "rcmip-concentrations-annual-means-v5-1-0.csv"
+            "https://rcmip-protocols-au.s3-ap-southeast-2.amazonaws.com/"
+            "v5.1.0/rcmip-concentrations-annual-means-v5-1-0.csv"
         ),
         known_hash="md5:0d82c3c3cdd4dd632b2bb9449a5c315f",
     )
 
     forcing_file = pooch.retrieve(
         url=(
-            "https://zenodo.org/records/4589756/files/"
-            "rcmip-radiative-forcing-annual-means-v5-1-0.csv"
+            "https://rcmip-protocols-au.s3-ap-southeast-2.amazonaws.com/"
+            "v5.1.0/rcmip-radiative-forcing-annual-means-v5-1-0.csv"
         ),
         known_hash="md5:87ef6cd4e12ae0b331f516ea7f82ccba",
     )

--- a/tests/unit_tests/io/fill_from_test.py
+++ b/tests/unit_tests/io/fill_from_test.py
@@ -1,7 +1,6 @@
 """Module for testing fill_from functions."""
 
 import os
-import time
 
 import numpy as np
 import pytest
@@ -219,12 +218,9 @@ def test_fill_from_csv():
     )
 
 
-# from here below, we introduce a small pause to override HTTP 429 errors on Zenodo
-# which was causing nightly automated GitHub actions tests to fail.
 def test_from_rcmip():
     ftest = minimal_ghg_run()
     ftest.fill_from_rcmip()
-    time.sleep(2)
 
 
 def test_fill_from_rcmip_missing_concentration_data():
@@ -232,7 +228,6 @@ def test_fill_from_rcmip_missing_concentration_data():
     ftest.scenarios = ["ADVANCE"]
     with pytest.raises(MissingDataError):
         ftest.fill_from_rcmip()
-        time.sleep(2)
 
 
 def test_fill_from_rcmip_missing_emissions_data():
@@ -248,7 +243,6 @@ def test_fill_from_rcmip_missing_emissions_data():
     fair_obj.allocate()
     with pytest.raises(MissingDataError):
         fair_obj.fill_from_rcmip()
-        time.sleep(2)
 
 
 def test_fill_from_rcmip_missing_forcing_data():
@@ -264,4 +258,3 @@ def test_fill_from_rcmip_missing_forcing_data():
     fair_obj.allocate()
     with pytest.raises(MissingDataError):
         fair_obj.fill_from_rcmip()
-        time.sleep(2)

--- a/tests/unit_tests/io/fill_from_test.py
+++ b/tests/unit_tests/io/fill_from_test.py
@@ -1,6 +1,7 @@
 """Module for testing fill_from functions."""
 
 import os
+import time
 
 import numpy as np
 import pytest
@@ -218,9 +219,12 @@ def test_fill_from_csv():
     )
 
 
+# from here below, we introduce a small pause to override HTTP 429 errors on Zenodo
+# which was causing nightly automated GitHub actions tests to fail.
 def test_from_rcmip():
     ftest = minimal_ghg_run()
     ftest.fill_from_rcmip()
+    time.sleep(2)
 
 
 def test_fill_from_rcmip_missing_concentration_data():
@@ -228,6 +232,7 @@ def test_fill_from_rcmip_missing_concentration_data():
     ftest.scenarios = ["ADVANCE"]
     with pytest.raises(MissingDataError):
         ftest.fill_from_rcmip()
+        time.sleep(2)
 
 
 def test_fill_from_rcmip_missing_emissions_data():
@@ -243,6 +248,7 @@ def test_fill_from_rcmip_missing_emissions_data():
     fair_obj.allocate()
     with pytest.raises(MissingDataError):
         fair_obj.fill_from_rcmip()
+        time.sleep(2)
 
 
 def test_fill_from_rcmip_missing_forcing_data():
@@ -258,3 +264,4 @@ def test_fill_from_rcmip_missing_forcing_data():
     fair_obj.allocate()
     with pytest.raises(MissingDataError):
         fair_obj.fill_from_rcmip()
+        time.sleep(2)


### PR DESCRIPTION
Continuous integration is now failing with HTTP 429 error from Zenodo when pulling in RCMIP files in GitHub actions but works on command line; too many requests being made in a short space of time.

Added in a 2-second pause between requests.