### PR TITLE
DOCS: there is no `_static` folder

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,6 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
 version = get_versions()["version"]
 release = version
 


### PR DESCRIPTION
# Pull request

Fixes warning in the docs build.

```python-traceback
WARNING: html_static_path entry '_static' does not exist
```


