### PR TITLE
DOCS: ignore warning

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,3 +52,6 @@ numfig = True
 
 # readthedocs being a pain
 master_doc = 'index'
+
+# ignore 'py:class reference target not found' warning
+nitpick_ignore = [('py:class', 'pd.DataFrame')]


### PR DESCRIPTION
# Pull request
Ignores the following sphinx warning:

```python-traceback
.../fair.py:docstring of fair.io.fill_from.fill_from_pandas:1: WARNING: py:class reference target not found: pd.DataFrame
```

Not sure why this generates a warning from the docstring when others don't (e.g. `np.ndarray`) but as no cross links etc. are generated I guess it's fine to just ignore.

After https://stackoverflow.com/a/30624034